### PR TITLE
expose route and middleware for finer-grained Express integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ The __fflip__ Express middleware includes a `Features` template variable that co
 *NOTE: This will only be populated if you call `req.fflip.setForUser` beforehand.*  
 The __fflip__ Express middleware also includes a `FeaturesJSON` template variable that is the JSON string of your user's enabled features. To deliver this down to the client, just make sure your template something like this: ``<script>var Features = {{ FeaturesJSON }}; </script>``. 
 
+####Low-level integration
+If you need a finer-grained Express integration, such as changing the URL for manual overrides, adding security middleware, or applying middleware on a subset of routes, you can use ``express_middleware`` and ``express_route`` directly.
+```
+app.use(fflip.express_middleware);
+app.get('/custom_path/:name/:action', fflip.express_route);
+```
 
 ##Special Thanks
 Original logo designed by <a href="http://thenounproject.com/Luboš Volkov" target="_blank">Luboš Volkov</a>

--- a/lib/fflip.js
+++ b/lib/fflip.js
@@ -182,7 +182,6 @@ var self = module.exports = {
 	 * @param {Response} res
 	 * @param {Function} next
 	 * @return {void}
-	 * @private
 	 */
 	express_middleware: function(req, res, next) {
 
@@ -208,7 +207,6 @@ var self = module.exports = {
 	 * @param {Response} res
 	 * @param {Function} next
 	 * @return {void}
-	 * @private
 	 */
 	express_route: function(req, res, next) {
 		var name = req.params.name;

--- a/lib/fflip.js
+++ b/lib/fflip.js
@@ -184,7 +184,7 @@ var self = module.exports = {
 	 * @return {void}
 	 * @private
 	 */
-	_express_middleware: function(req, res, next) {
+	express_middleware: function(req, res, next) {
 
 		// Attach the fflip object to the request
 		req.fflip = new FFlipRequestObject(self, req.cookies.fflip);
@@ -210,7 +210,7 @@ var self = module.exports = {
 	 * @return {void}
 	 * @private
 	 */
-	_express_route: function(req, res, next) {
+	express_route: function(req, res, next) {
 		var name = req.params.name;
 		var action = req.params.action;
 		var actionName = '';
@@ -274,9 +274,9 @@ var self = module.exports = {
 	 */
 	express: function(app) {
 		// Express Middleware
-		app.use(this._express_middleware);
+		app.use(this.express_middleware);
 		// Manual Flipping Route
-		app.get('/fflip/:name/:action', this._express_route);
+		app.get('/fflip/:name/:action', this.express_route);
 	},
 
 };

--- a/test/fflip.js
+++ b/test/fflip.js
@@ -211,7 +211,7 @@ describe('fflip', function(){
 
 		it('should set fflip object onto req', function(done) {
 			var me = this;
-			fflip._express_middleware(this.reqMock, this.resMock, function() {
+			fflip.express_middleware(this.reqMock, this.resMock, function() {
 				assert(me.reqMock.fflip);
 				assert(me.reqMock.fflip._flags, me.reqMock.cookies.fflip);
 				done();
@@ -220,7 +220,7 @@ describe('fflip', function(){
 
 		it('should allow res.render() to be called without model object', function(done) {
 			var me = this;
-			fflip._express_middleware(this.reqMock, this.resMock, function() {
+			fflip.express_middleware(this.reqMock, this.resMock, function() {
 				assert.doesNotThrow(function() {
 					me.resMock.render('testview');
 				});
@@ -230,7 +230,7 @@ describe('fflip', function(){
 
 		it('should wrap res.render() to set features object automatically', function(done) {
 			var me = this;
-			fflip._express_middleware(this.reqMock, this.resMock, function() {
+			fflip.express_middleware(this.reqMock, this.resMock, function() {
 				var features = {features : { fClosed: true }};
 				var featuresString = JSON.stringify(features);
 
@@ -249,7 +249,7 @@ describe('fflip', function(){
 		it('req.fflip.setFeatures() should call userFeatures() with cookie flags', function(done) {
 			var me = this;
 			var spy = sandbox.spy(fflip, 'userFeatures');
-			fflip._express_middleware(this.reqMock, this.resMock, function() {
+			fflip.express_middleware(this.reqMock, this.resMock, function() {
 				me.reqMock.fflip.setForUser(userXYZ);
 				assert(fflip.userFeatures.calledOnce);
 				assert(fflip.userFeatures.calledWith(userXYZ, {fClosed: false}));
@@ -260,7 +260,7 @@ describe('fflip', function(){
 
 		it('req.fflip.has() should get the correct features', function(done) {
 			var me = this;
-			fflip._express_middleware(this.reqMock, this.resMock, function() {
+			fflip.express_middleware(this.reqMock, this.resMock, function() {
 				me.reqMock.fflip.setForUser(userXYZ);
 				assert.strictEqual(me.reqMock.fflip.has('fOpen'), true);
 				assert.strictEqual(me.reqMock.fflip.has('fClosed'), false);
@@ -272,7 +272,7 @@ describe('fflip', function(){
 		it('req.fflip.has() should throw when called before features have been set', function() {
 			var me = this;
 			assert.throws(function() {
-				fflip._express_middleware(this.reqMock, this.resMock, function() {
+				fflip.express_middleware(this.reqMock, this.resMock, function() {
 					me.reqMock.fflip.has('fOpen');
 				});
 			});
@@ -281,7 +281,7 @@ describe('fflip', function(){
 		it('req.fflip.featuers should be an empty object if setFeatures() has not been called', function(done) {
 			var me = this;
 			var consoleErrorStub = sandbox.stub(console, 'error'); // Supress Error Output
-			fflip._express_middleware(this.reqMock, this.resMock, function() {
+			fflip.express_middleware(this.reqMock, this.resMock, function() {
 				assert.ok(isObjectEmpty(me.reqMock.fflip.features));
 				done();
 				consoleErrorStub.restore();
@@ -290,12 +290,12 @@ describe('fflip', function(){
 
 		it('should mount express middleware into provided app', function() {
 			fflip.express(this.appMock);
-			assert.ok(this.appMock.use.calledWith(fflip._express_middleware));
+			assert.ok(this.appMock.use.calledWith(fflip.express_middleware));
 		});
 
 		it('should add GET route for manual feature flipping into provided app', function() {
 			fflip.express(this.appMock);
-			assert.ok(this.appMock.get.calledWith('/fflip/:name/:action', fflip._express_route));
+			assert.ok(this.appMock.get.calledWith('/fflip/:name/:action', fflip.express_route));
 		});
 
 	});
@@ -319,7 +319,7 @@ describe('fflip', function(){
 		it('should propogate a 404 error if feature does not exist', function(done) {
 			var next = sandbox.stub();
 			this.reqMock.params.name = 'doesnotexist';
-			fflip._express_route(this.reqMock, this.resMock, function(err) {
+			fflip.express_route(this.reqMock, this.resMock, function(err) {
 				assert(err);
 				assert(err.fflip);
 				assert.equal(err.statusCode, 404);
@@ -330,7 +330,7 @@ describe('fflip', function(){
 		it('should propogate a 500 error if cookies are not enabled', function(done) {
 			var next = sandbox.stub();
 			this.reqMock.cookies = null;
-			fflip._express_route(this.reqMock, this.resMock, function(err) {
+			fflip.express_route(this.reqMock, this.resMock, function(err) {
 				assert(err);
 				assert(err.fflip);
 				assert.equal(err.statusCode, 500);
@@ -339,12 +339,12 @@ describe('fflip', function(){
 		});
 
 		it('should set the right cookie flags', function() {
-			fflip._express_route(this.reqMock, this.resMock);
+			fflip.express_route(this.reqMock, this.resMock);
 			assert(this.resMock.cookie.calledWithMatch('fflip', {fClosed: true}, { maxAge: 900000 }));
 		});
 
 		it('should send back 200 json response on successful call', function() {
-			fflip._express_route(this.reqMock, this.resMock);
+			fflip.express_route(this.reqMock, this.resMock);
 			assert(this.resMock.json.calledWith(200));
 		});
 
@@ -371,7 +371,7 @@ describe('fflip', function(){
 		// });
 
 		// it('should call res.cookie() on successful request', function() {
-		//   self._express_route(this.reqMock, this.resMock);
+		//   self.express_route(this.reqMock, this.resMock);
 		//   assert(res.cookie.calledWith('fflip'));
 		// });
 


### PR DESCRIPTION
I started using the fflip module, but then had to back it out when it wasn't clear the right way to secure the filter override URLs or apply the middleware to specific URLs and not as a global middleware. So I made this quick change to remove the '_' signaling private and write a quick note in the README to help the next guy. Thoughts?