### PR TITLE
Allow maxCookieAge to be specified

### DIFF
--- a/lib/fflip.js
+++ b/lib/fflip.js
@@ -106,6 +106,8 @@ var self = module.exports = {
 	// The reload rate for reloading the features
 	_reloadRate: 30*1000,
 
+	maxCookieAge: 900000,
+
 	/**
 	 * Configure fflip.
 	 * @param  {Object} params
@@ -256,7 +258,7 @@ var self = module.exports = {
 		}
 
 		// set new fflip cookie with new data
-		res.cookie('fflip', flags, { maxAge: 900000 });
+		res.cookie('fflip', flags, { maxAge: self.maxCookieAge });
 		res.json(200, {
 			feature: name,
 			action: action,

--- a/test/fflip.js
+++ b/test/fflip.js
@@ -343,6 +343,16 @@ describe('fflip', function(){
 			assert(this.resMock.cookie.calledWithMatch('fflip', {fClosed: true}, { maxAge: 900000 }));
 		});
 
+		it('should set the right cookie flags when maxCookieAge is set', function() {
+			var oneMonthMs = 31 * 86400 * 1000;
+			var oldMaxCookieAge = fflip.maxCookieAge;
+			fflip.maxCookieAge = oneMonthMs;
+			fflip.express_route(this.reqMock, this.resMock);
+			fflip.maxCookieAge = oldMaxCookieAge;
+
+			assert(this.resMock.cookie.calledWithMatch('fflip', {fClosed: true}, { maxAge: oneMonthMs }));
+		});
+
 		it('should send back 200 json response on successful call', function() {
 			fflip.express_route(this.reqMock, this.resMock);
 			assert(this.resMock.json.calledWith(200));


### PR DESCRIPTION
Currently fflip uses a `maxAge` value when setting the cookie of 900000, or 15 minutes.

This PR keeps the current default, but allows the user to override the value. 

For example, we would prefer a value of one month. This PR will allow us to override the value. 