### PR TITLE
Create new interface

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,14 +9,14 @@ module.exports = function(grunt) {
           reporter: 'nyan',
           ui: 'bdd'
         },
-        src: ['test/fflip.js']
+        src: ['test/*']
       },
       spec: {
         options: {
           reporter: 'spec',
           ui: 'bdd'
         },
-        src: ['test/fflip.js']
+        src: ['test/*']
       }
     }
   });

--- a/lib/fflip-request.js
+++ b/lib/fflip-request.js
@@ -2,6 +2,7 @@
 
  /**
   * FFlip Request Object - Express/Connect Helper
+  *
   * @param {FFlip} fflip The fflip main module
   * @param {[Object]} flags A set of feature overrides, these flags will
   *        take precedence over the normal feature criteria.
@@ -17,16 +18,18 @@ function FFlipRequestObject(fflip, flags) {
 
 /**
  * Sets the features for a given user
+  *
  * @param {Object} user A user object to test criteria against for each feature
  * @return {void}
  */
 FFlipRequestObject.prototype.setForUser = function(user) {
-	this.features = this._fflip.userFeatures(user, this._flags);
+	this.features = this._fflip.getFeaturesForUser(user, this._flags);
 	this.isSet = true;
 };
 
 /**
  * Check if a user has a certain feature enabled/disabled
+  *
  * @param  {string} featureName The name of the feature to check for
  * @return {Boolean} True if feature is enabled, false otherwise
  * @throws {Error} If features have not yet been set (via setForUser())

--- a/lib/fflip.js
+++ b/lib/fflip.js
@@ -1,6 +1,3 @@
-/**
- * @fileoverview FFlip - Feature Flipping Moduel
- */
 'use strict';
 
 
@@ -8,6 +5,7 @@
 // Requirements
 //--------------------------------------------------------------------------
 var FFlipRequestObject = require('./fflip-request');
+var util = require('util');
 
 
 //--------------------------------------------------------------------------
@@ -18,6 +16,7 @@ var getFeatures,
 
 /**
  * Set the criteria to the given object.
+ *
  * @param {Object} configVal
  * @return {void}
  * @private
@@ -28,6 +27,7 @@ function setCriteria(configVal) {
 
 /**
  * Set the features.
+ *
  * @param {Object} configVal
  * @return {void}
  * @private
@@ -46,6 +46,7 @@ function setFeatures(configVal) {
 
 /**
  * Update the features by reloading them, if possible.
+ *
  * @return {void}
  * @private
  */
@@ -66,6 +67,7 @@ function updateFeatures() {
 
 /**
  * The callback called by the user-defined function for reloading features.
+ *
  * @param {Object} data
  * @return {void}
  * @private
@@ -95,6 +97,7 @@ function setReload(rate) {
 //--------------------------------------------------------------------------
 // Public
 //--------------------------------------------------------------------------
+
 var self = module.exports = {
 
 	// Object containing all fflip features
@@ -110,6 +113,7 @@ var self = module.exports = {
 
 	/**
 	 * Configure fflip.
+	 *
 	 * @param  {Object} params
 	 * @return {void}
 	 */
@@ -122,6 +126,7 @@ var self = module.exports = {
 
 	/**
 	 * Reload the features, if a reload is possible.
+	 *
 	 * @return {void}
 	 */
 	reload: function() {
@@ -129,13 +134,14 @@ var self = module.exports = {
 	},
 
 	/**
-	 * Check if a user has some given feature, and returns a boolean.
-	 * Returns null if the feature does not exist.
-	 * @param {Object} user The User object that criterial will check against.
+	 * Check if a user has some given feature, and returns a boolean. Returns null
+	 * if the feature does not exist.
+	 *
 	 * @param {string} featureName The name of the feature to check for.
+	 * @param {Object} user The User object that criterial will check against.
 	 * @return {Boolean|null}
 	 */
-	userHasFeature: function(user, featureName) {
+	isFeatureEnabledForUser: function(featureName, user) {
 		var feature = self._features[featureName];
 		if(typeof feature != 'object') {
 			return null;
@@ -158,34 +164,37 @@ var self = module.exports = {
 
 	/**
 	 * Get the availability of all features for a given user.
+	 *
 	 * @param {Object} user The User object that criterial will check against.
 	 * @param {Object} flags A collection of overrides
-	 *        [@deprecated this flag will be removed soon]
 	 * @return {Object} The collection of all features and their availability.
 	 */
-	userFeatures: function(user, flags) {
+	getFeaturesForUser: function(user, flags) {
 		flags = flags || {};
-		var user_features = {};
-		Object.keys(self._features).forEach(function(featureName) {
-			if(flags[featureName] !== undefined) {
-				user_features[featureName] = flags[featureName];
-			} else {
-				user_features[featureName] = self.userHasFeature(user, featureName);
+		var userFeatures = {};
+		for (var featureName in self._features) {
+		  if (self._features.hasOwnProperty(featureName)) {
+				if(flags[featureName] !== undefined) {
+					userFeatures[featureName] = flags[featureName];
+				} else {
+					userFeatures[featureName] = self.isFeatureEnabledForUser(featureName, user);
+				}
 			}
-		});
-		return user_features;
+		}
+		return userFeatures;
 	},
 
 	/**
 	 * Express middleware. Attaches helper functions to the request object
 	 * and wrap the res.render to automatically include features in the
 	 * template.
+	 *
 	 * @param {Request} req
 	 * @param {Response} res
 	 * @param {Function} next
 	 * @return {void}
 	 */
-	express_middleware: function(req, res, next) {
+	expressMiddleware: function(req, res, next) {
 
 		// Attach the fflip object to the request
 		req.fflip = new FFlipRequestObject(self, req.cookies.fflip);
@@ -205,12 +214,13 @@ var self = module.exports = {
 
 	/**
 	 * Attach routes for manual feature flipping.
+	 *
 	 * @param {Request} req
 	 * @param {Response} res
 	 * @param {Function} next
 	 * @return {void}
 	 */
-	express_route: function(req, res, next) {
+	expressRoute: function(req, res, next) {
 		var name = req.params.name;
 		var action = req.params.action;
 		var actionName = '';
@@ -269,14 +279,23 @@ var self = module.exports = {
 
 	/**
 	 * Attach FFlip functionality to an express app. Includes helpers & routes.
+	 *
 	 * @param {Object} app An Express Application
 	 * @return {void}
 	 */
 	express: function(app) {
 		// Express Middleware
-		app.use(this.express_middleware);
+		app.use(this.expressMiddleware);
 		// Manual Flipping Route
-		app.get('/fflip/:name/:action', this.express_route);
+		app.get('/fflip/:name/:action', this.expressRoute);
 	},
 
 };
+
+/** @deprecated v2.x method names have been deprecated. These mappers will be removed in future versions. */
+self.express_route = util.deprecate(self.expressRoute, 'fflip.express_route: Use fflip.expressRoute instead');
+self.express_middleware = util.deprecate(self.expressMiddleware, 'fflip.express_middleware: Use fflip.expressMiddleware instead');
+self.userFeatures = util.deprecate(self.getFeaturesForUser, 'fflip.userFeatures: Use fflip.getFeaturesForUser instead');
+self.userHasFeature = util.deprecate(function(user, featureName) {
+	return self.isFeatureEnabledForUser(featureName, user);
+}, 'fflip.userHasFeature(user, featureName): Use fflip.isFeatureEnabledForUser(featureName, user) instead');

--- a/test/fflip-deprecated.js
+++ b/test/fflip-deprecated.js
@@ -1,0 +1,114 @@
+/**
+ * @fileoverview These tests exist to test old functionality and deprecated method
+ * signatures that are still supported. If these are breaking and cannot be easily
+ * fixed, they can be removed across major versions.
+ */
+
+'use strict';
+
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+var assert = require('assert');
+
+var fflip = require('../lib/fflip');
+
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var configData = {
+	criteria: {
+		c1: function(user, bool) {
+			return bool;
+		},
+		c2: function(user, flag) {
+			return user.flag == flag;
+		}
+	},
+	features: {
+		fEmpty: {},
+		fOpen: {
+			name: 'fOpen',
+			description: 'true for all users',
+			criteria: {
+				c1: true
+			}
+		},
+		fClosed: {
+			criteria: {
+				c1: false
+			}
+		},
+		fEval: {
+			criteria: {
+				c2: 'abc'
+			}
+		}
+	},
+	reload: 0
+};
+
+var userABC = {
+	flag: 'abc'
+};
+var userXYZ = {
+	flag: 'xyz'
+};
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe('fflip (deprecated)', function(){
+
+	describe('userHasFeature()', function(){
+
+		beforeEach(function() {
+			fflip.config(configData);
+		});
+
+		it('should return null if features does not exist', function(){
+			assert.equal(null, fflip.userHasFeature(userABC, 'notafeature'));
+		});
+
+		it('should return false if no criteria set', function(){
+			assert.equal(false, fflip.userHasFeature(userABC, 'fEmpty'));
+		});
+
+		it('should return false if all feature critieria evaluates to false', function(){
+			assert.equal(false, fflip.userHasFeature(userABC, 'fClosed'));
+			assert.equal(false, fflip.userHasFeature(userXYZ, 'fEval'));
+		});
+
+		it('should return true if one feature critieria evaluates to true', function(){
+			assert.equal(true, fflip.userHasFeature(userABC, 'fOpen'));
+			assert.equal(true, fflip.userHasFeature(userABC, 'fEval'));
+		});
+
+	});
+
+	describe('userFeatures()', function(){
+
+		it('userFeatures() is equivilent to getFeaturesForUser()', function() {
+			assert.deepEqual(fflip.userFeatures(userABC), fflip.getFeaturesForUser(userABC));
+		});
+
+	});
+
+	describe('express integration', function(){
+
+		it('express_middleware() still exists for v2.x backwards compatibility', function() {
+			assert(fflip.express_middleware);
+		});
+
+		it('express_route() still exists for v2.x backwards compatibility', function() {
+			assert(fflip.express_route);
+		});
+
+	});
+
+});

--- a/test/fflip.js
+++ b/test/fflip.js
@@ -140,40 +140,40 @@ describe('fflip', function(){
 
 	});
 
-	describe('userHasFeature()', function(){
+	describe('isFeatureEnabledForUser()', function() {
 
 		beforeEach(function() {
 			fflip.config(configData);
 		});
 
 		it('should return null if features does not exist', function(){
-			assert.equal(null, fflip.userHasFeature(userABC, 'notafeature'));
+			assert.equal(null, fflip.isFeatureEnabledForUser('notafeature', userABC));
 		});
 
 		it('should return false if no criteria set', function(){
-			assert.equal(false, fflip.userHasFeature(userABC, 'fEmpty'));
+			assert.equal(false, fflip.isFeatureEnabledForUser('fEmpty', userABC));
 		});
 
 		it('should return false if all feature critieria evaluates to false', function(){
-			assert.equal(false, fflip.userHasFeature(userABC, 'fClosed'));
-			assert.equal(false, fflip.userHasFeature(userXYZ, 'fEval'));
+			assert.equal(false, fflip.isFeatureEnabledForUser('fClosed', userABC));
+			assert.equal(false, fflip.isFeatureEnabledForUser('fEval', userXYZ));
 		});
 
 		it('should return true if one feature critieria evaluates to true', function(){
-			assert.equal(true, fflip.userHasFeature(userABC, 'fOpen'));
-			assert.equal(true, fflip.userHasFeature(userABC, 'fEval'));
+			assert.equal(true, fflip.isFeatureEnabledForUser('fOpen', userABC));
+			assert.equal(true, fflip.isFeatureEnabledForUser('fEval', userABC));
 		});
 
 	});
 
-	describe('userFeatures()', function(){
+	describe('getFeaturesForUser()', function(){
 
 		beforeEach(function() {
 			fflip.config(configData);
 		});
 
 		it('should return an object of features for a user', function(){
-			var featuresABC = fflip.userFeatures(userABC);
+			var featuresABC = fflip.getFeaturesForUser(userABC);
 			assert.equal(featuresABC.fEmpty, false);
 			assert.equal(featuresABC.fOpen, true);
 			assert.equal(featuresABC.fClosed, false);
@@ -181,9 +181,9 @@ describe('fflip', function(){
 		});
 
 		it('should overwrite values when flags are set', function() {
-			var featuresXYZ = fflip.userFeatures(userXYZ);
+			var featuresXYZ = fflip.getFeaturesForUser(userXYZ);
 			assert.equal(featuresXYZ.fEval, false);
-			featuresXYZ = fflip.userFeatures(userXYZ, {fEval: true});
+			featuresXYZ = fflip.getFeaturesForUser(userXYZ, {fEval: true});
 			assert.equal(featuresXYZ.fEval, true);
 		});
 
@@ -211,7 +211,7 @@ describe('fflip', function(){
 
 		it('should set fflip object onto req', function(done) {
 			var me = this;
-			fflip.express_middleware(this.reqMock, this.resMock, function() {
+			fflip.expressMiddleware(this.reqMock, this.resMock, function() {
 				assert(me.reqMock.fflip);
 				assert(me.reqMock.fflip._flags, me.reqMock.cookies.fflip);
 				done();
@@ -220,7 +220,7 @@ describe('fflip', function(){
 
 		it('should allow res.render() to be called without model object', function(done) {
 			var me = this;
-			fflip.express_middleware(this.reqMock, this.resMock, function() {
+			fflip.expressMiddleware(this.reqMock, this.resMock, function() {
 				assert.doesNotThrow(function() {
 					me.resMock.render('testview');
 				});
@@ -230,7 +230,7 @@ describe('fflip', function(){
 
 		it('should wrap res.render() to set features object automatically', function(done) {
 			var me = this;
-			fflip.express_middleware(this.reqMock, this.resMock, function() {
+			fflip.expressMiddleware(this.reqMock, this.resMock, function() {
 				var features = {features : { fClosed: true }};
 				var featuresString = JSON.stringify(features);
 
@@ -246,13 +246,13 @@ describe('fflip', function(){
 			});
 		});
 
-		it('req.fflip.setFeatures() should call userFeatures() with cookie flags', function(done) {
+		it('req.fflip.setFeatures() should call getFeaturesForUser() with cookie flags', function(done) {
 			var me = this;
-			var spy = sandbox.spy(fflip, 'userFeatures');
-			fflip.express_middleware(this.reqMock, this.resMock, function() {
+			var spy = sandbox.spy(fflip, 'getFeaturesForUser');
+			fflip.expressMiddleware(this.reqMock, this.resMock, function() {
 				me.reqMock.fflip.setForUser(userXYZ);
-				assert(fflip.userFeatures.calledOnce);
-				assert(fflip.userFeatures.calledWith(userXYZ, {fClosed: false}));
+				assert(fflip.getFeaturesForUser.calledOnce);
+				assert(fflip.getFeaturesForUser.calledWith(userXYZ, {fClosed: false}));
 				spy.restore();
 				done();
 			});
@@ -260,7 +260,7 @@ describe('fflip', function(){
 
 		it('req.fflip.has() should get the correct features', function(done) {
 			var me = this;
-			fflip.express_middleware(this.reqMock, this.resMock, function() {
+			fflip.expressMiddleware(this.reqMock, this.resMock, function() {
 				me.reqMock.fflip.setForUser(userXYZ);
 				assert.strictEqual(me.reqMock.fflip.has('fOpen'), true);
 				assert.strictEqual(me.reqMock.fflip.has('fClosed'), false);
@@ -272,7 +272,7 @@ describe('fflip', function(){
 		it('req.fflip.has() should throw when called before features have been set', function() {
 			var me = this;
 			assert.throws(function() {
-				fflip.express_middleware(this.reqMock, this.resMock, function() {
+				fflip.expressMiddleware(this.reqMock, this.resMock, function() {
 					me.reqMock.fflip.has('fOpen');
 				});
 			});
@@ -281,7 +281,7 @@ describe('fflip', function(){
 		it('req.fflip.featuers should be an empty object if setFeatures() has not been called', function(done) {
 			var me = this;
 			var consoleErrorStub = sandbox.stub(console, 'error'); // Supress Error Output
-			fflip.express_middleware(this.reqMock, this.resMock, function() {
+			fflip.expressMiddleware(this.reqMock, this.resMock, function() {
 				assert.ok(isObjectEmpty(me.reqMock.fflip.features));
 				done();
 				consoleErrorStub.restore();
@@ -290,12 +290,12 @@ describe('fflip', function(){
 
 		it('should mount express middleware into provided app', function() {
 			fflip.express(this.appMock);
-			assert.ok(this.appMock.use.calledWith(fflip.express_middleware));
+			assert.ok(this.appMock.use.calledWith(fflip.expressMiddleware));
 		});
 
 		it('should add GET route for manual feature flipping into provided app', function() {
 			fflip.express(this.appMock);
-			assert.ok(this.appMock.get.calledWith('/fflip/:name/:action', fflip.express_route));
+			assert.ok(this.appMock.get.calledWith('/fflip/:name/:action', fflip.expressRoute));
 		});
 
 	});
@@ -319,7 +319,7 @@ describe('fflip', function(){
 		it('should propogate a 404 error if feature does not exist', function(done) {
 			var next = sandbox.stub();
 			this.reqMock.params.name = 'doesnotexist';
-			fflip.express_route(this.reqMock, this.resMock, function(err) {
+			fflip.expressRoute(this.reqMock, this.resMock, function(err) {
 				assert(err);
 				assert(err.fflip);
 				assert.equal(err.statusCode, 404);
@@ -330,7 +330,7 @@ describe('fflip', function(){
 		it('should propogate a 500 error if cookies are not enabled', function(done) {
 			var next = sandbox.stub();
 			this.reqMock.cookies = null;
-			fflip.express_route(this.reqMock, this.resMock, function(err) {
+			fflip.expressRoute(this.reqMock, this.resMock, function(err) {
 				assert(err);
 				assert(err.fflip);
 				assert.equal(err.statusCode, 500);
@@ -339,7 +339,7 @@ describe('fflip', function(){
 		});
 
 		it('should set the right cookie flags', function() {
-			fflip.express_route(this.reqMock, this.resMock);
+			fflip.expressRoute(this.reqMock, this.resMock);
 			assert(this.resMock.cookie.calledWithMatch('fflip', {fClosed: true}, { maxAge: 900000 }));
 		});
 
@@ -347,14 +347,14 @@ describe('fflip', function(){
 			var oneMonthMs = 31 * 86400 * 1000;
 			var oldMaxCookieAge = fflip.maxCookieAge;
 			fflip.maxCookieAge = oneMonthMs;
-			fflip.express_route(this.reqMock, this.resMock);
+			fflip.expressRoute(this.reqMock, this.resMock);
 			fflip.maxCookieAge = oldMaxCookieAge;
 
 			assert(this.resMock.cookie.calledWithMatch('fflip', {fClosed: true}, { maxAge: oneMonthMs }));
 		});
 
 		it('should send back 200 json response on successful call', function() {
-			fflip.express_route(this.reqMock, this.resMock);
+			fflip.expressRoute(this.reqMock, this.resMock);
 			assert(this.resMock.json.calledWith(200));
 		});
 
@@ -381,7 +381,7 @@ describe('fflip', function(){
 		// });
 
 		// it('should call res.cookie() on successful request', function() {
-		//   self.express_route(this.reqMock, this.resMock);
+		//   self.expressRoute(this.reqMock, this.resMock);
 		//   assert(res.cookie.calledWith('fflip'));
 		// });
 


### PR DESCRIPTION
Resolves #10 
Creates new interface to prepare for new v3 features/updates.
Deprecates (but doesn't remove) old interface.

- `fflip.userHasFeature(user, featureName)` -> `fflip.isFeatureEnabledForUser(featureName, user)`
- `fflip.userFeatures(user)` -> `fflip.getFeaturesForUser(user)`
- `fflip.express_middleware()` -> `fflip.expressMiddleware()`
- `fflip.express_route()` -> `fflip.expressRoute()`
- `fflip.express()` not removed. No good reason to remove now if people are happily using it, and considering we'll be pulling all this express logic out later.