### PR TITLE
Deprecated flags argument on getFeaturesForUser() method

### DIFF
--- a/lib/fflip.js
+++ b/lib/fflip.js
@@ -281,10 +281,16 @@ var self = module.exports = {
 	 * Get the availability of all features for a given user.
 	 *
 	 * @param {Object} user The User object that criterial will check against.
-	 * @param {Object} flags A collection of overrides
+	 * @param {Object} flags A collection of overrides (@deprecated)
 	 * @return {Object} The collection of all features and their availability.
 	 */
 	getFeaturesForUser: function(user, flags) {
+
+		// @deprecated: Flag override behavior is no longer needed in core, and will be removed soon
+		if (typeof flags !== undefined) {
+			console.error('fflip: getFeaturesForUser() "flags" argument is deprecated and will be removed soon.');
+		}
+
 		flags = flags || {};
 		var userFeatures = {};
 		for (var featureName in self.features) {

--- a/test/fflip-deprecated.js
+++ b/test/fflip-deprecated.js
@@ -11,7 +11,6 @@
 // Requirements
 //------------------------------------------------------------------------------
 var assert = require('assert');
-
 var fflip = require('../lib/fflip');
 
 


### PR DESCRIPTION
The express behavior used this logic, which made more sense when it was all one library. Now that it's been pulled out, this can be handled by fflip-express itself without polluting core. Other than that, no one was using / should have been using this.

This argument's use has already been removed from `fflip-express`.