### PR TITLE
Add support for async criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,21 +38,31 @@ fflip.config({
 });
 
 // Get all of a user's enabled features...
-someFreeUser.features = fflip.getFeaturesForUser(someFreeUser);
-if(someFreeUser.features.closedBeta === true) {
+fflip.getFeaturesForUser(someFreeUser)
+  .then(features => someFreeUser.features = features)
+  .then(() => {
+    if (someFreeUser.features.closedBeta === true) {
+      console.log('Welcome to the Closed Beta!'));
+    }
+  });
+
+// ... or just check a single feature.
+return fflip.isFeatureEnabledForUser('closedBeta', someFreeUser)
+  .then(inClosedBeta => inClosedBeta && console.log('Welcome to the Closed Beta!'));
+
+// Use the sync functions if no async checks are needed
+if (fflip.isFeatureEnabledForUserSync('closedBeta', someFreeUser) === true) {
   console.log('Welcome to the Closed Beta!');
 }
 
-// ... or just check this single feature.
-if (fflip.isFeatureEnabledForUser('closedBeta', someFreeUser) === true) {
-  console.log('Welcome to the Closed Beta!');
-}
 ```
 
 
 ### Criteria
 
 **Criteria** are the rules that define access to different features. Each criteria takes a user object and some data as arguments, and returns true/false if the user matches that criteria. You will use these criteria to restrict/allow features for different subsets of your userbase.
+
+If the criteria returns a Promise, it is considered async and cannot be used with the synchronous API.
 
 ```javascript
 let ExampleCriteria = [
@@ -72,6 +82,13 @@ let ExampleCriteria = [
     id: 'allowUserIDs',
     check: function(user, allowedIDs) {
       return allowedIDs.indexOf(user.id) > -1;
+    }
+  },
+  {
+    id: 'underMessageLimit',
+    check: function(user, maxMessages) {
+      return Db.countMessages(user)
+        .then(count => count < maxMessages);
     }
   }
 ];
@@ -128,8 +145,10 @@ If you'd like to allow wider access to your feature while still preventing a spe
 ## Usage
 
 - `.config(options) -> void`: Configure fflip (see below)
-- `.isFeatureEnabledForUser(featureName, user) -> boolean`: Return true/false if featureName is enabled for user
-- `.getFeaturesForUser(user) -> Object`: Return object of true/false for all features for user
+- `.isFeatureEnabledForUser(featureName, user) -> Promise`: Resolves true/false if featureName is enabled for user
+- `.isFeatureEnabledForUserSync(featureName, user) -> boolean`: Returns true/false if featureName is enabled for user
+- `.getFeaturesForUser(user) -> Object`: Resolves object of true/false for all features for user
+- `.getFeaturesForUserSync(user) -> Object`: Returns object of true/false for all features for user
 - `.reload() -> void`: Force a reload (if loading features dynamically)
 
 

--- a/lib/fflip.js
+++ b/lib/fflip.js
@@ -1,11 +1,11 @@
 'use strict';
 
+var Promise = global.Promise;
 
 //--------------------------------------------------------------------------
 // Requirements
 //--------------------------------------------------------------------------
 var util = require('util');
-
 
 //--------------------------------------------------------------------------
 // Private
@@ -135,35 +135,105 @@ function setReload(rate) {
 }
 
 /**
- * Evaluate a set of critera. Return true if ALL criteria is met.
+ * @private
+ *
+ * Grabs the criteria for a feature, given its name. Evaluates the criteria
+ * instantly if it has an `enabled` key or is not an object.
+ *
+ * @param  {String}               featureName The feature's name.
+ * @return {boolean|array}             The criteria, or true/false.
+ */
+function getFeatureCriteria(featureName) {
+	var feature = self.features[featureName];
+
+	// If feature does not exist, return null
+	if (typeof feature === 'undefined') {
+		return null;
+	}
+	// If feature isn't an object, something has gone terribly wrong
+	// TODO(fks) 03-10-2016: Check for this on config, not on the fly
+	if (typeof feature !== 'object') {
+		throw new Error('fflip: Features are formatted incorrectly.');
+	}
+	// If feature.enabled is set, return its boolean form
+	if (typeof feature.enabled !== 'undefined') {
+		return !!feature.enabled;
+	}
+	// If feature.criteria is some non-object (or array), return its boolean form
+	if (typeof feature.criteria !== 'object') {
+		return !!feature.criteria;
+	}
+
+	if (Array.isArray(feature.criteria)) {
+		return feature.criteria.length > 0 ? feature.criteria : false;
+	}
+
+	return [feature.criteria];
+}
+
+/**
+ * Evaluate a set of synchronous criteria. Returns true if ALL criteria are met.
  *
  * @param {Object} criteriaSet The set of criteria, where each key is a criteria ID
  *        and each value is some data to send to that criteria function.
  * @param {Object} user The expected user object to check against in each criteria function.
  * @return {boolean} Returns true if ALL criteria are met, false otherwise.
+ * @throws {Error} If at least one of the criteria returns a Promise.
  */
-function evaluateCriteriaSet(criteriaSet, user) {
+function evaluateCriteriaSetSync(criteriaSet, user) {
 	return Object.keys(criteriaSet).reduce(function(currentResult, cName) {
 		if (cName === '$veto') {
 			return currentResult;
 		}
+
 		var criteria = self.criteria[cName];
 		var criteriaLogic = criteria.check;
 		var criteriaDataArgument = criteriaSet[cName];
-		return (criteriaLogic(user, criteriaDataArgument) && currentResult);
+		var result = criteriaLogic(user, criteriaDataArgument);
+
+		if (result && result.then) {
+			throw new Error('Unexpected asynchronous criteria: ' + cName);
+		}
+
+		return result && currentResult;
 	}, true);
 }
 
 /**
- * Evaluate a list of criteria. Return true if ANY one member evaluates to true, and no
- * "vetoing" members evaluate to false.
+ * Evaluate a set of possibly async criteria. Resolves true if ALL criteria are met.
+ *
+ * @param {Object} criteriaSet The set of criteria, where each key is a criteria ID
+ *        and each value is some data to send to that criteria function.
+ * @param {Object} user The expected user object to check against in each criteria function.
+ * @return {Promise} Resolves true if ALL criteria are met, false otherwise.
+ */
+function evaluateCriteriaSet(criteriaSet, user) {
+	return Promise.all(Object.keys(criteriaSet).map(function(cName) {
+		if (cName === '$veto') return true;
+
+		var checkCriteria = self.criteria[cName].check;
+		var checkArgument = criteriaSet[cName];
+
+		return checkCriteria(user, checkArgument);
+	}))
+	.then(function(results) {
+		return results.reduce(function(acc, result) {
+			return acc && result;
+		}, true);
+	});
+}
+
+/**
+ * Evaluate a list of synchronous criteria. Return true if ANY one member
+ * evaluates to true, and no "vetoing" members evaluate to false.
 
  * @param {Object} criteriaList A list of criteria sets or nested criteria lists.
  * @param {Object} user The expected user object to check against in each criteria function.
  * @return {boolean} Returns true if if ANY one member evaluates to true, and no "vetoing"
  * members evaluate to false. Returns false otherwise.
+ * @throws {Error} If at least one of the criteria in the list is asynchronous.
  */
-function evaluateCriteriaList(criteriaList, user) {
+function evaluateCriteriaListSync(criteriaList, user) {
 	var isEnabled = false;
 
 	for (var i = 0, l = criteriaList.length; i < l; i++) {
@@ -172,10 +242,10 @@ function evaluateCriteriaList(criteriaList, user) {
 
 		if (Array.isArray(listMember)) {
 			// if array, repeat this logic on each member of array, return true if ANY return true & NO vetos return false`
-			memberResult = evaluateCriteriaList(listMember, user);
+			memberResult = evaluateCriteriaListSync(listMember, user);
 		} else {
 			// if object, evaluate all and return true if ALL return true
-			memberResult = evaluateCriteriaSet(listMember, user);
+			memberResult = evaluateCriteriaSetSync(listMember, user);
 		}
 
 		if (listMember.$veto && !memberResult) {
@@ -188,6 +258,41 @@ function evaluateCriteriaList(criteriaList, user) {
 	return isEnabled;
 }
 
+/**
+ * Evaluate a list of possibly asynchronous criteria. Return true if ANY one
+ * member resolves to true, and no "vetoing" members resolve to false.
+
+ * @param {Object} criteriaList A list of criteria sets or nested criteria lists.
+ * @param {Object} user The expected user object to check against in each criteria function.
+ * @return {Promise} Resolves true if if ANY one member resolves to true, and no "vetoing"
+ * members evaluate to false. Resolves false otherwise.
+ */
+function evaluateCriteriaList(criteriaList, user) {
+	var vetos = [], nonVetos = [];
+
+	return Promise.all(criteriaList.map(function(listMember) {
+		var resultPromise;
+
+		if (Array.isArray(listMember)) {
+			resultPromise = evaluateCriteriaList(listMember, user);
+		} else {
+			resultPromise = evaluateCriteriaSet(listMember, user);
+		}
+
+		return resultPromise.then(function(res) {
+			(listMember.$veto ? vetos : nonVetos).push(res);
+		});
+	}))
+	.then(function() {
+		var isVetoed = vetos.reduce(function(acc, result) {
+			return acc || !result;
+		}, false);
+
+		return !isVetoed && nonVetos.reduce(function(acc, result) {
+			return acc || result;
+		}, vetos.length > 0);
+	});
+}
 
 //--------------------------------------------------------------------------
 // Public
@@ -234,65 +339,77 @@ var self = module.exports = {
 		getFeatures(getFeaturesCallback);
 	},
 
-	/**
-	 * Check if a user has some given feature, and returns a boolean. Returns null
-	 * if the feature does not exist.
-	 *
-	 * @param {string} featureName The name of the feature to check for.
-	 * @param {Object} user The User object that criterial will check against.
-	 * @return {Boolean|null}
-	 */
 	isFeatureEnabledForUser: function(featureName, user) {
-		var feature = self.features[featureName];
+		var featureCriteria = getFeatureCriteria(featureName);
 
-		// If feature does not exist, return null
-		if (typeof feature === 'undefined') {
-			return null;
-		}
-		// If feature isn't an object, something has gone terribly wrong
-		// TODO(fks) 03-10-2016: Check for this on config, not on the fly
-		if (typeof feature !== 'object') {
-			throw new Error('fflip: Features are formatted incorrectly.');
-		}
-		// If feature.enabled is set, return its boolean form
-		if (typeof feature.enabled !== 'undefined') {
-			return !!feature.enabled;
-		}
-		// If feature.criteria is some non-object, return its boolean form
-		if (typeof feature.criteria !== 'object') {
-			return !!feature.criteria;
-		}
-
-		var featureCriteria;
-		if (Array.isArray(feature.criteria)) {
-			featureCriteria = feature.criteria;
-		} else {
-			featureCriteria = [feature.criteria];
-		}
-
-		if(featureCriteria.length == 0) {
-			return false;
-		}
+		if (!Array.isArray(featureCriteria)) return Promise.resolve(featureCriteria);
 
 		return evaluateCriteriaList(featureCriteria, user);
 	},
 
 	/**
-	 * Get the availability of all features for a given user.
+	 * Check if a user has some given feature, and returns a boolean. Returns null
+	 * if the feature does not exist.
 	 *
-	 * @param {Object} user The User object that criterial will check against.
+	 * @param {string} featureName The name of the feature to check for.
+	 * @param {Object} user        The User object that criterial will check against.
+	 * @return {Boolean|null}
+	 */
+	isFeatureEnabledForUserSync: function(featureName, user) {
+		var featureCriteria = getFeatureCriteria(featureName);
+
+		if (!Array.isArray(featureCriteria)) return featureCriteria;
+
+		return evaluateCriteriaListSync(featureCriteria, user);
+	},
+
+	/**
+	 * Get the availability of all features for a given user asyncronously.
+	 *
+	 * @param {Object} user  The User object that criterial will check against.
 	 * @param {Object} flags A collection of overrides
-	 * @return {Object} The collection of all features and their availability.
+	 * @return {Object}      The collection of all features and their availability.
 	 */
 	getFeaturesForUser: function(user, flags) {
 		flags = flags || {};
 		var userFeatures = {};
+
+		var validFeatures = Object.keys(self.features).filter(function(featureName) {
+			return self.features.hasOwnProperty(featureName);
+		});
+
+		return Promise.all(validFeatures.map(function(featureName) {
+			if (typeof flags[featureName] !== 'undefined') {
+				return (userFeatures[featureName] = flags[featureName]);
+			}
+
+			return self.isFeatureEnabledForUser(featureName, user)
+				.then(function(isEnabled) {
+					return userFeatures[featureName] = isEnabled;
+				});
+		}))
+		.then(function() {
+			return userFeatures;
+		});
+	},
+
+	/**
+	 * Get the availability of all features for a given user, synchrously.
+	 *
+	 * @param {Object} user The User object that criterial will check against.
+	 * @param {Object} flags A collection of overrides
+	 * @return {Object} The collection of all features and their availability.
+	 * @throws {Error} If at least one of the features is asynchronous.
+	 */
+	getFeaturesForUserSync: function(user, flags) {
+		flags = flags || {};
+		var userFeatures = {};
 		for (var featureName in self.features) {
 			if (self.features.hasOwnProperty(featureName)) {
-				if(flags[featureName] !== undefined) {
+				if (flags[featureName] !== undefined) {
 					userFeatures[featureName] = flags[featureName];
 				} else {
-					userFeatures[featureName] = self.isFeatureEnabledForUser(featureName, user);
+					userFeatures[featureName] = self.isFeatureEnabledForUserSync(featureName, user);
 				}
 			}
 		}
@@ -305,11 +422,10 @@ var self = module.exports = {
 	express_route: throwExpressNoLongerSupportedError,
 	expressRoute: throwExpressNoLongerSupportedError,
 	express: throwExpressNoLongerSupportedError
-
 };
 
 /** @deprecated v3.x method names have been deprecated. These mappers will be removed in future versions. */
-self.userFeatures = util.deprecate(self.getFeaturesForUser, 'fflip.userFeatures: Use fflip.getFeaturesForUser instead');
+self.userFeatures = util.deprecate(self.getFeaturesForUserSync, 'fflip.userFeatures: Use fflip.getFeaturesForUserSync instead');
 self.userHasFeature = util.deprecate(function(user, featureName) {
-	return self.isFeatureEnabledForUser(featureName, user);
-}, 'fflip.userHasFeature(user, featureName): Use fflip.isFeatureEnabledForUser(featureName, user) instead');
+	return self.isFeatureEnabledForUserSync(featureName, user);
+}, 'fflip.userHasFeature(user, featureName): Use fflip.isFeatureEnabledForUserSync(featureName, user) instead');

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "eslint-plugin-react": "^4.2.1",
     "grunt": "~0.4.1",
     "grunt-mocha-test": "~0.7.0",
+    "mocha-as-promised": "^2.0.0",
     "sinon": "~1.7.3",
     "supertest": "~0.8.1"
   },

--- a/test/fflip-deprecated.js
+++ b/test/fflip-deprecated.js
@@ -70,13 +70,10 @@ var userXYZ = {
 //------------------------------------------------------------------------------
 
 describe('fflip (deprecated)', function(){
-
 	beforeEach(function() {
 		fflip.config(configData);
 	})
-
 	describe('userHasFeature()', function(){
-
 		beforeEach(function() {
 			fflip.config(configData);
 		});
@@ -98,19 +95,15 @@ describe('fflip (deprecated)', function(){
 			assert.equal(true, fflip.userHasFeature(userABC, 'fOpen'));
 			assert.equal(true, fflip.userHasFeature(userABC, 'fEval'));
 		});
-
 	});
 
 	describe('userFeatures()', function(){
-
-		it('userFeatures() is equivilent to getFeaturesForUser()', function() {
-			assert.deepEqual(fflip.userFeatures(userABC), fflip.getFeaturesForUser(userABC));
+		it('userFeatures() is equivalent to getFeaturesForUserSync()', function() {
+			assert.deepEqual(fflip.userFeatures(userABC), fflip.getFeaturesForUserSync(userABC));
 		});
-
 	});
 
 	describe('express support', function(){
-
 		it('throws error when called', function() {
 			assert.throws(function() { fflip.express_middleware(); }, /fflip: Express support is no longer bundled/);
 			assert.throws(function() { fflip.expressMiddleware(); }, /fflip: Express support is no longer bundled/);
@@ -118,7 +111,5 @@ describe('fflip (deprecated)', function(){
 			assert.throws(function() { fflip.expressRoute(); }, /fflip: Express support is no longer bundled/);
 			assert.throws(function() { fflip.express(); }, /fflip: Express support is no longer bundled/);
 		});
-
 	});
-
 });


### PR DESCRIPTION
This PR changes the standard API in order to support asynchronous criteria (i.e: that return promises).

Using this one can query databases, make external calls, etc. to determine whether a user has access to a feature or not.

I've kept support for the original synchronous API by adding the *Sync suffix to the existing functions. Also added some docs for explaining the new behaviour.