### PR TITLE
Add callback for async feature loading

### DIFF
--- a/lib/fflip.js
+++ b/lib/fflip.js
@@ -86,10 +86,11 @@ function setCriteria(configVal) {
  * Set the features.
  *
  * @param {Object} configVal
+ * @param {function} callback
  * @return {void}
  * @private
  */
-function setFeatures(configVal) {
+function setFeatures(configVal, callback) {
 	if (typeof configVal === 'function') {
 
 		if (configVal.length > 1) {
@@ -97,7 +98,7 @@ function setFeatures(configVal) {
 		}
 
 		getFeatures = configVal;
-		self.reload();
+		self.reload(callback);
 		return;
 	}
 
@@ -109,11 +110,16 @@ function setFeatures(configVal) {
  * The callback called by the user-defined function for reloading features.
  *
  * @param {Object} data
+ * @param {function} callback
  * @return {void}
  * @private
  */
-function getFeaturesCallback(data) {
+function getFeaturesCallback(data, callback) {
 	self.features = processUserFeatures(data) || self.features;
+
+	if (typeof callback !== 'undefined') {
+		callback();
+	}
 }
 
 /**
@@ -208,21 +214,23 @@ var self = module.exports = {
 	 * Configure fflip.
 	 *
 	 * @param  {Object} params
+	 * @param  {function} callback
 	 * @return {void}
 	 */
-	config: function(params) {
+	config: function(params, callback) {
 		// Set Criteria & Features
 		setCriteria(params.criteria);
-		setFeatures(params.features);
+		setFeatures(params.features, callback);
 		setReload(params.reload);
 	},
 
 	/**
 	 * Reload the features, if a reload is possible.
 	 *
+	 * @param  {function} callback
 	 * @return {void}
 	 */
-	reload: function() {
+	reload: function(callback) {
 		if(!getFeatures) {
 			return;
 		}
@@ -231,7 +239,9 @@ var self = module.exports = {
 			return;
 		}
 
-		getFeatures(getFeaturesCallback);
+		getFeatures(function(data) {
+			getFeaturesCallback(data, callback);
+		});
 	},
 
 	/**

--- a/test/fflip.js
+++ b/test/fflip.js
@@ -161,6 +161,24 @@ describe('fflip', function(){
 			fflip.config({features: loadAsyncronously, criteria: configData.criteria});
 		});
 
+		it('should invoke the callback after asynchronous features have been loaded', function(done){
+			var loadAsyncronously = function(callback) {
+				callback(configData.features);
+			};
+			fflip.config({features: loadAsyncronously, criteria: configData.criteria}, function() {
+				assert.deepEqual(fflip.features, {
+					fEmpty: configData.features[0],
+					fOpen: configData.features[1],
+					fClosed: configData.features[2],
+					fEval: configData.features[3],
+					fEvalOr: configData.features[4],
+					fEvalComplex: configData.features[5],
+					fEvalVeto: configData.features[6]
+				});
+				done();
+			});
+		});
+
 		it('should set criteria if given static criteria array', function(){
 			fflip.criteria = {};
 			fflip.config(configData);
@@ -204,6 +222,17 @@ describe('fflip', function(){
 			fflip.config({features: loadAsyncronously, criteria: configData.criteria});
 			testReady = true;
 			fflip.reload();
+		});
+
+		it('should invoke the callback after asynchronous features have been loaded', function(done) {
+			this.timeout(100);
+			var loadAsyncronously = function(callback) {
+				callback({});
+			};
+			fflip.config({features: loadAsyncronously, criteria: configData.criteria});
+			fflip.reload(function() {
+				done();
+			});
 		});
 
 	});


### PR DESCRIPTION
This PR adds an optional callback parameter to `config` and `reload`, which is invoked when asynchronous features have been loaded.

closes #18 