### PR TITLE
Stop reload functionality

### DIFF
--- a/lib/fflip.js
+++ b/lib/fflip.js
@@ -133,11 +133,18 @@ function setReload(rate) {
 	// Set the new reload rate
 	self._reloadRate = rate * 1000 || self._reloadRate;
 	// Clear any current interval
-	clearInterval(reloadInverval);
+    stopReload();
 	// Set a new interval, if applicable
 	if(getFeatures) {
 		reloadInverval = setInterval(self.reload, self._reloadRate);
 	}
+}
+
+/**
+ * Stops automatic reload.
+ * */
+function stopReload() {
+	clearInterval(reloadInverval);
 }
 
 /**
@@ -242,6 +249,13 @@ var self = module.exports = {
 		getFeatures(function(data) {
 			getFeaturesCallback(data, callback);
 		});
+	},
+
+	/**
+	 * Stops automatic reload of features.
+	 * */
+	stopReload: function() {
+		stopReload();
 	},
 
 	/**

--- a/package.json
+++ b/package.json
@@ -1,21 +1,19 @@
 {
-  "name": "@khajvah/fflip",
+  "name": "fflip",
   "description": "Advanced Feature Flipping/Toggling Across the Server and Client",
   "author": "Fred Schott <fkschott@gmail.com>",
   "licence": "MIT",
   "version": "4.0.0",
   "main": "lib/fflip",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/FredKSchott/fflip.git"
-  },
-  "bugs": {
-    "url": "https://github.com/FredKSchott/fflip/issues"
-  },
+  "repository": "FredKSchott/fflip",
+  "bugs": "https://github.com/FredKSchott/fflip/issues",
   "scripts": {
     "test": "grunt travis --verbose"
   },
   "devDependencies": {
+    "eslint": "^2.3.0",
+    "eslint-config-airbnb": "^6.1.0",
+    "eslint-plugin-react": "^4.2.1",
     "grunt": "~0.4.1",
     "grunt-mocha-test": "~0.7.0",
     "sinon": "~1.7.3",
@@ -31,11 +29,5 @@
     "feature flag",
     "feature flagging",
     "continuous integration"
-  ],
-  "homepage": "https://github.com/FredKSchott/fflip#readme",
-  "directories": {
-    "lib": "lib",
-    "test": "test"
-  },
-  "license": "ISC"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
     "test": "grunt travis --verbose"
   },
   "devDependencies": {
-    "eslint": "^2.3.0",
-    "eslint-config-airbnb": "^6.1.0",
-    "eslint-plugin-react": "^4.2.1",
     "grunt": "~0.4.1",
     "grunt-mocha-test": "~0.7.0",
     "sinon": "~1.7.3",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,17 @@
 {
-  "name": "fflip",
+  "name": "@khajvah/fflip",
   "description": "Advanced Feature Flipping/Toggling Across the Server and Client",
   "author": "Fred Schott <fkschott@gmail.com>",
   "licence": "MIT",
   "version": "4.0.0",
   "main": "lib/fflip",
-  "repository": "FredKSchott/fflip",
-  "bugs": "https://github.com/FredKSchott/fflip/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/FredKSchott/fflip.git"
+  },
+  "bugs": {
+    "url": "https://github.com/FredKSchott/fflip/issues"
+  },
   "scripts": {
     "test": "grunt travis --verbose"
   },
@@ -26,5 +31,11 @@
     "feature flag",
     "feature flagging",
     "continuous integration"
-  ]
+  ],
+  "homepage": "https://github.com/FredKSchott/fflip#readme",
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "license": "ISC"
 }


### PR DESCRIPTION
SetInterval hooks were holding my tests in running state indefinitely. Couldn't find a way of clearing intervals "manually".