### PR TITLE
Improve asynchronous failure handling

### DIFF
--- a/lib/fflip.js
+++ b/lib/fflip.js
@@ -107,22 +107,6 @@ function setFeatures(configVal, callback) {
 }
 
 /**
- * The callback called by the user-defined function for reloading features.
- *
- * @param {Object} data
- * @param {function} callback
- * @return {void}
- * @private
- */
-function getFeaturesCallback(data, callback) {
-	self.features = processUserFeatures(data) || self.features;
-
-	if (typeof callback !== 'undefined') {
-		callback();
-	}
-}
-
-/**
  * Sets the reload rate for fetching new features.
 
  * @param {int} rate The interval to fetch new features on, in seconds
@@ -239,8 +223,20 @@ var self = module.exports = {
 			return;
 		}
 
-		getFeatures(function(data) {
-			getFeaturesCallback(data, callback);
+		getFeatures(function(err, data) {
+			if(typeof err === 'undefined') {
+				try {
+					self.features = processUserFeatures(data) || self.features;
+				} catch(e) {
+					err = e;
+				}
+			}
+
+			if(typeof callback !== 'undefined') {
+				callback(err);
+			} else {
+				throw err;
+			}
 		});
 	},
 

--- a/lib/fflip.js
+++ b/lib/fflip.js
@@ -224,7 +224,7 @@ var self = module.exports = {
 		}
 
 		getFeatures(function(err, data) {
-			if(typeof err === 'undefined') {
+			if(!err) {
 				try {
 					self.features = processUserFeatures(data) || self.features;
 				} catch(e) {

--- a/test/fflip.js
+++ b/test/fflip.js
@@ -146,7 +146,7 @@ describe('fflip', function(){
 
 		it('should set features if given an asyncronous loading function', function(done){
 			var loadAsyncronously = function(callback) {
-				callback(configData.features);
+				callback(undefined, configData.features);
 				assert.deepEqual(fflip.features, {
 					fEmpty: configData.features[0],
 					fOpen: configData.features[1],
@@ -163,9 +163,10 @@ describe('fflip', function(){
 
 		it('should invoke the callback after asynchronous features have been loaded', function(done){
 			var loadAsyncronously = function(callback) {
-				callback(configData.features);
+				callback(undefined, configData.features);
 			};
-			fflip.config({features: loadAsyncronously, criteria: configData.criteria}, function() {
+			fflip.config({features: loadAsyncronously, criteria: configData.criteria}, function(err) {
+				assert.equal(err, undefined);
 				assert.deepEqual(fflip.features, {
 					fEmpty: configData.features[0],
 					fOpen: configData.features[1],
@@ -175,6 +176,17 @@ describe('fflip', function(){
 					fEvalComplex: configData.features[5],
 					fEvalVeto: configData.features[6]
 				});
+				done();
+			});
+		});
+
+		it('should invoke the callback after asynchronous features have failed', function(done){
+			var error = new Error();
+			var loadAsyncronously = function(callback) {
+				callback(error);
+			};
+			fflip.config({features: loadAsyncronously, criteria: configData.criteria}, function(err) {
+				assert.equal(err, error);
 				done();
 			});
 		});
@@ -205,7 +217,7 @@ describe('fflip', function(){
 		it('should be called every X seconds where X = reloadRate', function(done) {
 			this.timeout(205);
 			var loadAsyncronously = function(callback) {
-				callback({});
+				callback(undefined, {});
 				done();
 			};
 			fflip.config({features: loadAsyncronously, reload: 0.2, criteria: configData.criteria});
@@ -215,7 +227,7 @@ describe('fflip', function(){
 			this.timeout(100);
 			var testReady = false;
 			var loadAsyncronously = function(callback) {
-				callback({});
+				callback(undefined, {});
 				if(testReady)
 					done();
 			};
@@ -227,10 +239,26 @@ describe('fflip', function(){
 		it('should invoke the callback after asynchronous features have been loaded', function(done) {
 			this.timeout(100);
 			var loadAsyncronously = function(callback) {
-				callback({});
+				callback(undefined, {});
 			};
 			fflip.config({features: loadAsyncronously, criteria: configData.criteria});
-			fflip.reload(function() {
+			fflip.reload(function(err) {
+				assert.equal(err, undefined);
+				done();
+			});
+		});
+
+		it('should invoke the callback after asynchronous features have failed', function(done) {
+			this.timeout(100);
+			var error = new Error();
+			var testReady = false;
+			var loadAsyncronously = function(callback) {
+				callback(testReady ? error : undefined, {});
+			};
+			fflip.config({features: loadAsyncronously, criteria: configData.criteria});
+			testReady = true;
+			fflip.reload(function(err) {
+				assert.equal(err, error);
 				done();
 			});
 		});

--- a/test/fflip.js
+++ b/test/fflip.js
@@ -166,7 +166,7 @@ describe('fflip', function(){
 				callback(undefined, configData.features);
 			};
 			fflip.config({features: loadAsyncronously, criteria: configData.criteria}, function(err) {
-				assert.equal(err, undefined);
+				assert(!err);
 				assert.deepEqual(fflip.features, {
 					fEmpty: configData.features[0],
 					fOpen: configData.features[1],
@@ -243,7 +243,7 @@ describe('fflip', function(){
 			};
 			fflip.config({features: loadAsyncronously, criteria: configData.criteria});
 			fflip.reload(function(err) {
-				assert.equal(err, undefined);
+				assert(!err);
 				done();
 			});
 		});


### PR DESCRIPTION
This PR improves upon https://github.com/FredKSchott/fflip/pull/20 by adding better handling of asynchronous failures. As an example, we use asynchronous features loading to query our database, which can error. Currently we don't have a way to catch and handle those failures.

This PR updates the `callback`-function for `config` and `reload`, such that it accepts two arguments: `err` and `data`. This means that it conforms to the common error-first callback style, i.e. taking a `(err, value) => ...` function. Further, it means that you can easily promisify the two functions as follows:

```node
const util = require('util');

const promisifiedReload = util.promisify(fflip.reload);
const promisifiedConfig = util.promisify(fflip.config);
```

Note that this is a breaking change  😞 